### PR TITLE
Remove NewRelic RPM Gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -53,7 +53,6 @@ group :production do
   gem "aws-sdk-s3", require: false
   gem 'dalli'
   gem 'sendgrid-ruby'
-  gem 'newrelic_rpm'
   gem 'sentry-raven'
   gem 'sidekiq'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -599,7 +599,6 @@ GEM
       timeout
     net-smtp (0.5.0)
       net-protocol
-    newrelic_rpm (9.7.1)
     nio4r (2.7.3)
     nokogiri (1.13.6-aarch64-linux)
       racc (~> 1.4)
@@ -949,7 +948,6 @@ DEPENDENCIES
   letter_opener_web
   listen
   matrix
-  newrelic_rpm
   nokogiri (= 1.13.6)
   psych (< 4)
   puma

--- a/app.json
+++ b/app.json
@@ -7,7 +7,6 @@
     "heroku-redis",
     "logentries:le_tryit",
     "memcachedcloud:30",
-    "newrelic:wayne",
     "sendgrid:starter"
   ],
   "scripts": {


### PR DESCRIPTION
### Description
Remove NewRelic RPM gem.
Also I remove the newrelic instance from app.json (I think it is a configuration for Heroku)