### PR TITLE
Fixes in impersonatable_users and term_customizer

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,7 +9,7 @@ GIT
 
 GIT
   remote: https://github.com/CodiTramuntana/decidim-module-term_customizer.git
-  revision: e369bc933f06fd1e47d6987fa6e408f0a2549e73
+  revision: a751e475e157bf220a2185ccaefe34c08e1a429f
   branch: upgrade/decidim_0.29
   specs:
     decidim-term_customizer (0.29.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,7 +9,7 @@ GIT
 
 GIT
   remote: https://github.com/CodiTramuntana/decidim-module-term_customizer.git
-  revision: a751e475e157bf220a2185ccaefe34c08e1a429f
+  revision: a92bfae0375db042db72970dee92ee4ccd0be1e3
   branch: upgrade/decidim_0.29
   specs:
     decidim-term_customizer (0.29.0)

--- a/config/initializers/decidim.rb
+++ b/config/initializers/decidim.rb
@@ -104,7 +104,3 @@ Rails.application.config.i18n.default_locale = Decidim.default_locale
 
 # Inform Decidim about the assets folder
 Decidim.register_assets_path File.expand_path("app/packs", Rails.application.root)
-
-Decidim::Verifications.register_workflow(:sms_direct) do |workflow|
-  workflow.form = "Decidim::Verifications::SmsDirectHandler"
-end


### PR DESCRIPTION
A misreferenced and duplicate SmsDirectHandler check that was causing an error when handling a new participant has been removed.

The button to add restrictions to a translation group was not working. The term_customizer module has been updated and the problem has been fixed.